### PR TITLE
solved footer elements not getting centered

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -48,5 +48,14 @@
 }
 
 .footer__link-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   --ifm-footer-link-hover-color: var(--ifm-color-primary-white);
+}
+
+.footer__title {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
## 🛠️ Fixes Issue
Closes #36 

## 👨‍💻 Changes proposed

1] Made footer__link elements to align at center
2] Made footer__title elements to align at center

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->


- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📷 Screenshots
### Before :
![Screenshot from 2022-10-01 23-47-49](https://user-images.githubusercontent.com/92677342/193423775-0fcb96fb-1f7b-4f2e-90b0-769bc116bf37.png)

### After :
![Screenshot from 2022-10-01 23-48-07](https://user-images.githubusercontent.com/92677342/193423846-d14d3ada-cecc-41ad-b7db-08df4598b4c5.png)

