### PR TITLE
Added 'Page under construction!' flag and fixed a blog

### DIFF
--- a/blog/2021-08-26-welcome/index.md
+++ b/blog/2021-08-26-welcome/index.md
@@ -8,4 +8,4 @@ tags: [announcements, federated learning, differential privacy]
 Blog page is currently under development, stay tuned for the upcoming blogs.
 
 If you want to write a blog or contribute in our projects please 
-contact sourav [at] openprivacytech [dot] org
+contact [Sourav](https://github.com/souravcipher) at [openprivacytech.org](https://github.com/openprivacytech/openprivacytech.org)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,3 +3,5 @@ sidebar_position: 1
 ---
 
 # Privacy Tech
+
+`This page is under construction!`

--- a/src/pages/jobs.md
+++ b/src/pages/jobs.md
@@ -1,1 +1,3 @@
 # Jobs
+
+`This page is under construction!`


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Added "Page under construction!" flag to the required pages.

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed

- The pages which are under construction have no flag to tell the user if the page is under construction or not.  For example the Jobs page and the Docs pages both are empty.

Under Hacktoberfest, I have added the `Page under construction` flag wherever necessary.

- Also the first blog post has issues that show "[at]" and "[dot]"

<img width="960" alt="3" src="https://user-images.githubusercontent.com/95699355/193455467-4ed27c34-05a3-4812-bde8-54b01c783b6a.png">

I have addressed this also, now, it gets redirected to the repository page.

<!-- List all the proposed changes in your PR -->

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📷 Screenshots

<img width="960" alt="1" src="https://user-images.githubusercontent.com/95699355/193455574-4edb741a-585b-4545-8e06-54dab084c877.png">

<img width="960" alt="2" src="https://user-images.githubusercontent.com/95699355/193455578-72a77200-30b2-4a50-ad85-5b0a04b0ef00.png">

<img width="960" alt="4" src="https://user-images.githubusercontent.com/95699355/193455587-5491cab1-f772-4470-a7de-94ee951a6064.png">